### PR TITLE
Bugfix: Apply existing "double-appt-removal" logic to Dispo data processing

### DIFF
--- a/mridle/data_management.py
+++ b/mridle/data_management.py
@@ -593,6 +593,17 @@ def filter_duplicate_patient_time_slots(slot_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def build_dispo_e1_df(dispo_examples: List[Dict]) -> pd.DataFrame:
+    """
+    Convert the dispo data from validation experiment 1 into a dataframe and process it. Processing steps include:
+    - formatting column data types
+    - de-duping double show+canceled appointments
+
+    Args:
+        dispo_examples: Raw yaml list of dictionaries.
+
+    Returns: Dataframe of appointments collected in validation experiment 1.
+
+    """
     dispo_slot_df = build_dispo_df(dispo_examples)
 
     # use same de-duping function, create columns as necessary
@@ -604,6 +615,18 @@ def build_dispo_e1_df(dispo_examples: List[Dict]) -> pd.DataFrame:
 
 
 def build_dispo_e2_df(dispo_examples: List[Dict]) -> pd.DataFrame:
+    """
+        Convert the dispo data from validation experiment 2 into a dataframe and process it. Processing steps include:
+        - formatting column data types
+        - identifying rescheduled no shows from the sequence of dispo data points
+        - de-duping double show+canceled appointments
+
+        Args:
+            dispo_examples: Raw yaml list of dictionaries.
+
+        Returns: Dataframe of appointments collected in validation experiment 1.
+
+        """
     dispo_df = build_dispo_df(dispo_examples)
     dispo_slot_df = find_no_shows_from_dispo_exp_two(dispo_df)
 


### PR DESCRIPTION
* Included the `filter_duplicate_patient_time_slots` function into dispo data processing pipeline (to remove double appts where there are 2 appts for the same patient and the same time, one is show and the other cancel). 
* Wrote wrappers for `build_dispo_e1_df` and `build_dispo_e2_df` separately. Previously, the user had to remember that for experiment 1, you run `build_dispo_df`, but for exp 2, you have to do `build_dispo_df` and then also `find_no_shows_from_dispo_exp_two`. 